### PR TITLE
Fix default speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 2021-07-22
+
+### Fixed
+
+- Default speed is now read correctly
+
 ## [1.3.3] - 2021-07-21
 
 ### Fixed

--- a/youtube_series_downloader/core/channel.py
+++ b/youtube_series_downloader/core/channel.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from youtube_series_downloader.config import config
 
@@ -9,13 +9,16 @@ class Channel:
         name: str = "",
         id: str = "",
         collection_dir: str = "",
-        speed: float = config.general.speed_up_default,
+        speed: Optional[float] = None,
         includes: List[str] = [],
         excludes: List[str] = [],
     ):
         self.name = name
         self.id = id
         self.collection_dir = collection_dir
-        self.speed = speed
         self.includes = includes
         self.excludes = excludes
+        if speed:
+            self.speed: float = speed
+        else:
+            self.speed: float = config.general.speed_up_default


### PR DESCRIPTION
### What changed?
- The default speed was always set to 1.0 regardless of configuration

### Testing
- [ ] Added unit tests
- [X] Manually tested

### Checklist
- [X] I have performed a self-review of my code

