### PR TITLE
Multiple channels in one series folder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 
 ### Testing
 - [ ] Added unit tests
-- [ ] ...Your own tests...
+- [ ] Tested manually
 
 ### Checklist
 - [ ] I have performed a self-review of my code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- If quitting the application in the middle of a render youtube_dl would get stuck next time
+- If quitting the application in the middle of a render ffmpeg would get stuck next time
   since you had to confirm the replacement of the file
 
 ## [1.3.4] - 2021-07-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2021-07-23
+
+### Added
+
+- Multiple channels can now have the same name and use a common episode counter [#25](https://github.com/Senth/youtube-series-downloader/issues/25)
+  - This is useful when a content creator has multiple channels but you want to put them
+    into the same series.
+- Quits application if configuration is missing required settings
+  - `series_dir = /media/series` under `[General]`
+  - `id = youtube_channel_id` under `[Channel Name]`
+
+### Fixed
+
+- If quitting the application in the middle of a render youtube_dl would get stuck next time
+  since you had to confirm the replacement of the file
+
 ## [1.3.4] - 2021-07-22
 
 ### Fixed

--- a/youtube_series_downloader/__main__.py
+++ b/youtube_series_downloader/__main__.py
@@ -22,6 +22,7 @@ config_gateway = ConfigGateway()
 def main():
     check_for_programs()
     config.set_cli_args(get_args())
+    config_gateway.check_config_exists()
     init_logs()
 
     if config.daemon:

--- a/youtube_series_downloader/core/channel.py
+++ b/youtube_series_downloader/core/channel.py
@@ -22,3 +22,24 @@ class Channel:
             self.speed: float = speed
         else:
             self.speed: float = config.general.speed_up_default
+
+    def __members(self):
+        return (
+            self.name,
+            self.id,
+            self.collection_dir,
+            self.speed,
+            self.includes,
+            self.excludes,
+        )
+
+    def __eq__(self, other) -> bool:
+        if type(other) is type(self):
+            return self.__members() == other.__members()
+        return False
+
+    def __hash__(self) -> int:
+        return hash(self.__members())
+
+    def __repr__(self) -> str:
+        return str(self.__members())

--- a/youtube_series_downloader/gateways/config_gateway.py
+++ b/youtube_series_downloader/gateways/config_gateway.py
@@ -17,6 +17,7 @@ class ConfigGateway:
         self.path = Path.home().joinpath(f".{config.app_name}.cfg")
         self.parser = ConfigParser(interpolation=ExtendedInterpolation())
 
+    def check_config_exists(self) -> None:
         if not self.path.exists():
             TealPrint.info(f"Could not find any configuration file in {self.path}")
             user_input = input("Do you want to copy the example config and edit it (y/n)?")
@@ -47,6 +48,9 @@ class ConfigGateway:
             "float:speed_up_default",
             "int:max_days_back",
         )
+        if not general.series_dir:
+            TealPrint.warning(f"Missing 'series_dir' in [General] in your configuration. Please add it.", exit=True)
+
         return general
 
     def get_channels(self) -> List[Channel]:
@@ -59,11 +63,18 @@ class ConfigGateway:
                     channel,
                     section,
                     "id",
+                    "name",
                     "dir->collection_dir",
                     "float:speed",
                     "str_list:includes",
                     "str_list:excludes",
                 )
+
+                if not channel.id:
+                    TealPrint.warning(
+                        f"Missing 'id' for channel [{section}] in your configuration. Please add it.", exit=True
+                    )
+
                 channels.append(channel)
         return channels
 

--- a/youtube_series_downloader/gateways/config_gateway_test.py
+++ b/youtube_series_downloader/gateways/config_gateway_test.py
@@ -92,7 +92,7 @@ from youtube_series_downloader.gateways.config_gateway import ConfigGateway
 )
 def test_get_channels(name: str, config_str: str, expected: List[Channel]) -> None:
     print(name)
-    
+
     config.general = General()
     gateway = ConfigGateway()
     gateway.parser.read_string(config_str)

--- a/youtube_series_downloader/gateways/config_gateway_test.py
+++ b/youtube_series_downloader/gateways/config_gateway_test.py
@@ -1,0 +1,148 @@
+from typing import List
+
+import pytest
+from youtube_series_downloader.config import General, config
+from youtube_series_downloader.core.channel import Channel
+from youtube_series_downloader.gateways.config_gateway import ConfigGateway
+
+
+@pytest.mark.parametrize(
+    "name,config_str,expected",
+    [
+        (
+            "Minimum channel, only an id",
+            """
+            [Channel Name]
+            id = UChFur_NwVSbUozOcF_F2kMf
+            """,
+            [
+                Channel(name="Channel Name", id="UChFur_NwVSbUozOcF_F2kMf"),
+            ],
+        ),
+        (
+            "Changing channel name",
+            """
+            [Channel Name]
+            id = UChFur_NwVSbUozOcF_F2kMf
+            name = Another name
+            """,
+            [
+                Channel(name="Another name", id="UChFur_NwVSbUozOcF_F2kMf"),
+            ],
+        ),
+        (
+            "Collection dir",
+            """
+            [Channel Name]
+            id = UChFur_NwVSbUozOcF_F2kMf
+            dir = some/dir
+            """,
+            [
+                Channel(name="Channel Name", id="UChFur_NwVSbUozOcF_F2kMf", collection_dir="some/dir"),
+            ],
+        ),
+        (
+            "Speed",
+            """
+            [Channel Name]
+            id = UChFur_NwVSbUozOcF_F2kMf
+            speed = 0.8
+            """,
+            [
+                Channel(name="Channel Name", id="UChFur_NwVSbUozOcF_F2kMf", speed=0.8),
+            ],
+        ),
+        (
+            "Includes",
+            """
+            [Channel Name]
+            id = UChFur_NwVSbUozOcF_F2kMf
+            includes =
+                test
+                another string
+            """,
+            [
+                Channel(name="Channel Name", id="UChFur_NwVSbUozOcF_F2kMf", includes=["test", "another string"]),
+            ],
+        ),
+        (
+            "Excludes",
+            """
+            [Channel Name]
+            id = UChFur_NwVSbUozOcF_F2kMf
+            excludes =
+                test
+                another string
+            """,
+            [
+                Channel(name="Channel Name", id="UChFur_NwVSbUozOcF_F2kMf", excludes=["test", "another string"]),
+            ],
+        ),
+        (
+            "Changing channel name",
+            """
+            [Channel Name]
+            id = UChFur_NwVSbUozOcF_F2kMf
+            """,
+            [
+                Channel(name="Channel Name", id="UChFur_NwVSbUozOcF_F2kMf"),
+            ],
+        ),
+    ],
+)
+def test_get_channels(name: str, config_str: str, expected: List[Channel]) -> None:
+    print(name)
+    
+    config.general = General()
+    gateway = ConfigGateway()
+    gateway.parser.read_string(config_str)
+
+    channels = gateway.get_channels()
+
+    assert expected == channels
+
+
+def test_required_channel_id() -> None:
+    gateway = ConfigGateway()
+    config_str = """
+        [Channel Name]
+        name = Another name
+    """
+    gateway.parser.read_string(config_str)
+
+    with pytest.raises(SystemExit) as e:
+        gateway.get_channels()
+
+    assert e.type == SystemExit
+    assert e.value.code == 1
+
+
+def test_get_default_speed() -> None:
+    config.general.speed_up_default = 1.5
+    gateway = ConfigGateway()
+    config_str = """
+        [Channel Name]
+        id = UChFur_NwVSbUozOcF_F2kMf
+    """
+    expected = [Channel(name="Channel Name", id="UChFur_NwVSbUozOcF_F2kMf", speed=1.5)]
+
+    gateway.parser.read_string(config_str)
+
+    channels = gateway.get_channels()
+
+    assert expected == channels
+
+
+def test_required_series_dir() -> None:
+    gateway = ConfigGateway()
+    config_str = """
+        [General]
+        serie_dir = invalid/name
+    """
+    gateway.parser.read_string(config_str)
+
+    with pytest.raises(SystemExit) as e:
+        gateway.get_general()
+
+    assert e.type == SystemExit
+    assert e.value.code == 1

--- a/youtube_series_downloader/gateways/ffmpeg_gateway.py
+++ b/youtube_series_downloader/gateways/ffmpeg_gateway.py
@@ -26,6 +26,7 @@ class FfmpegGateway:
                 subprocess.run(
                     [
                         "ffmpeg",
+                        "-y",
                         "-i",
                         in_file,
                         "-metadata",

--- a/youtube_series_downloader/gateways/youtube_dl_gateway.py
+++ b/youtube_series_downloader/gateways/youtube_dl_gateway.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from tempfile import gettempdir
 from typing import Optional
 
+from tealprint.tealprint import TealLevel
 from youtube_dl import YoutubeDL
 from youtube_series_downloader.config import config
 from youtube_series_downloader.core.video import Video
@@ -15,8 +16,15 @@ class YoutubeDlGateway:
         if config.pretend:
             return out_file
 
+        quiet = config.level.value >= TealLevel.verbose.value
+        no_warnings = config.level.value >= TealLevel.warning.value
+        verbose = config.level.value >= TealLevel.debug.value
+
         ydl_opts = {
             "outtmpl": str(out_file),
+            "quiet": quiet,
+            "verbose": verbose,
+            "no_warnings": no_warnings,
             "merge_output_format": "mkv",
         }
         with YoutubeDL(ydl_opts) as ydl:


### PR DESCRIPTION
### What changed?
- Multiple channels can now be placed in the same series folder by setting its `name = something` field in the configuration
- Quits the application if the required configuration fields are missing
- Force-quitting the application in the middle of a doesn't make it get stuck on subsequent runs

### Testing
- [x] Added unit tests
- [x] Manually

### Checklist
- [x] I have performed a self-review of my code

### Related Issues
Fixes #25 
