### PR TITLE
Fix resetting log indentation when exception is thrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Upcoming]
+
+### Fixed
+
+- Logging indentation is not reset when an exception is thrown [#33](https://github.com/Senth/youtube-series-downloader/issues/33)
+
 ## [1.5.0] - 2021-11-04
 
 ### Added

--- a/youtube_series_downloader/__main__.py
+++ b/youtube_series_downloader/__main__.py
@@ -67,6 +67,7 @@ def _run_once():
         download_new_episodes = DownloadNewEpisodes(app_repo)
         download_new_episodes.execute(channels)
     finally:
+        TealPrint.clear_indent()
         app_repo.close()
 
 


### PR DESCRIPTION
### What changed?
- Fix logging indentation

### Testing
- [ ] Added unit tests
- [ ] Tested manually

### Checklist
- [X] I have performed a self-review of my code

### Related Issues
Fixes #33
