### PR TITLE
Use `yt-dlp` instead of `youtube-dl` to download videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Upcoming]
+## [1.5.1] - 2021-11-13
 
 ### Fixed
 
 - Logging indentation is not reset when an exception is thrown [#33](https://github.com/Senth/youtube-series-downloader/issues/33)
+- Changed from `youtube-dl` to `yt-dlp` to once again download videos in full speed [#32](https://github.com/Senth/youtube-series-downloader/issues/32)
 
 ## [1.5.0] - 2021-11-04
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tealprint==0.2.1
 blulib==0.1.1
 requests==2.22.0
 APScheduler==3.7.0
+yt-dlp==2021.11.10.1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "blulib==0.1.1",
         "requests",
         "tealprint==0.2.1",
-        "youtube-dl",
+        "yt-dlp",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/youtube_series_downloader/gateways/youtube_dl_gateway.py
+++ b/youtube_series_downloader/gateways/youtube_dl_gateway.py
@@ -3,9 +3,9 @@ from tempfile import gettempdir
 from typing import Optional
 
 from tealprint.tealprint import TealLevel
-from youtube_dl import YoutubeDL
 from youtube_series_downloader.config import config
 from youtube_series_downloader.core.video import Video
+from yt_dlp import YoutubeDL
 
 
 class YoutubeDlGateway:


### PR DESCRIPTION
`youtube-dl` is not maintained any longer, while `yt-dlp` is.

### What changed?
- Using `yt-dlp` instead of 

### Testing
- [ ] Added unit tests
- [X] Tested manually

### Checklist
- [x] I have performed a self-review of my code

### Related Issues
Fixes #32
